### PR TITLE
Add showing only errors flag and exclude pattern

### DIFF
--- a/PhpDocblockChecker/CheckerCommand.php
+++ b/PhpDocblockChecker/CheckerCommand.php
@@ -53,6 +53,11 @@ class CheckerCommand extends Command
     protected $skipMethods = false;
 
     /**
+     * @var boolean
+     */
+    protected $showOnlyErrors = true;
+
+    /**
      * @var OutputInterface
      */
     protected $output;
@@ -66,7 +71,8 @@ class CheckerCommand extends Command
             ->addOption('directory', 'd', InputOption::VALUE_REQUIRED, 'Directory to scan.', './')
             ->addOption('skip-classes', null, InputOption::VALUE_NONE, 'Don\'t check classes for docblocks.')
             ->addOption('skip-methods', null, InputOption::VALUE_NONE, 'Don\'t check methods for docblocks.')
-            ->addOption('json', 'j', InputOption::VALUE_NONE, 'Output JSON instead of a log.');
+            ->addOption('json', 'j', InputOption::VALUE_NONE, 'Output JSON instead of a log.')
+            ->addOption('output-only-errors', null, InputOption::VALUE_NONE, 'Show only errors');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -79,6 +85,7 @@ class CheckerCommand extends Command
         $this->output = $output;
         $this->skipClasses = $input->getOption('skip-classes');
         $this->skipMethods = $input->getOption('skip-methods');
+        $this->showOnlyErrors = $input->getOption('output-only-errors');
 
         // Set up excludes:
         if (!is_null($exclude)) {
@@ -170,7 +177,7 @@ class CheckerCommand extends Command
                 }
             }
 
-            if (!$errors && $this->verbose) {
+            if (!$errors && $this->verbose && !$this->showOnlyErrors) {
                 $this->output->writeln($name . ' <info>OK</info>');
             }
         }

--- a/PhpDocblockChecker/CheckerCommand.php
+++ b/PhpDocblockChecker/CheckerCommand.php
@@ -67,7 +67,7 @@ class CheckerCommand extends Command
         $this
             ->setName('check')
             ->setDescription('Check PHP files within a directory for appropriate use of Docblocks.')
-            ->addOption('exclude', 'x', InputOption::VALUE_REQUIRED, 'Files and directories to exclude.', null)
+            ->addOption('exclude', 'x', InputOption::VALUE_REQUIRED, 'Files and directories to exclude. You can use exlude patterns ex. */Tests/*', null)
             ->addOption('directory', 'd', InputOption::VALUE_REQUIRED, 'Directory to scan.', './')
             ->addOption('skip-classes', null, InputOption::VALUE_NONE, 'Don\'t check classes for docblocks.')
             ->addOption('skip-methods', null, InputOption::VALUE_NONE, 'Don\'t check methods for docblocks.')
@@ -119,7 +119,7 @@ class CheckerCommand extends Command
 
             $itemPath = $path . $item->getFilename();
 
-            if (in_array($itemPath, $this->exclude)) {
+            if ($this->exclude($itemPath)) {
                 continue;
             }
 
@@ -183,5 +183,38 @@ class CheckerCommand extends Command
         }
 
 
+    }
+
+    /**
+     * Check if path should be excluded
+     *
+     * @param  string $path
+     *
+     * @return boolean True if path has matched pattern
+     */
+    protected function exclude($path)
+    {
+        foreach ($this->exclude as $pattern) {
+
+            $replacements = array(
+             '\\,' => ',',
+             '*'   => '.*',
+            );
+
+            // We assume a / directory separator, as do the exclude rules
+            // most developers write, so we need a special case for any system
+            // that is different.
+            if (DIRECTORY_SEPARATOR === '\\') {
+                $replacements['/'] = '\\\\';
+            }
+
+            $pattern = strtr($pattern, $replacements);
+
+            if (preg_match("|{$pattern}|i", $path) === 1) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }


### PR DESCRIPTION
Output can be sometimes very big depends on how many files are checked it could be useful to see only errors skipping correct files.

Like in PHP Codesniffer it is very useful just to exclude pattern ex. `*/Test/*` from all directories ex:

`src/Acme/DemoBundle/Test`
`src/Acme/BlogBundle/Test`
