### PR TITLE
Feature: Allow nullable params to be checked

### DIFF
--- a/PhpDocblockChecker/CheckerCommand.php
+++ b/PhpDocblockChecker/CheckerCommand.php
@@ -358,21 +358,29 @@ class CheckerCommand extends Command
                                 'line' => $method['line'],
                                 'param' => $param,
                             ];
-                        } elseif (!empty($type) && $method['docblock']['params'][$param] != $type) {
-                            if ($type == 'array' && substr($method['docblock']['params'][$param], -2) == '[]') {
-                                // Do nothing because this is fine.
-                            } else {
-                                $warnings = true;
-                                $this->warnings[] = [
-                                    'type' => 'param-mismatch',
-                                    'file' => $file,
-                                    'class' => $name,
-                                    'method' => $name,
-                                    'line' => $method['line'],
-                                    'param' => $param,
-                                    'param-type' => $type,
-                                    'doc-type' => $method['docblock']['params'][$param],
-                                ];
+                        } elseif (!empty($type)) {
+                            $docBlockTypes = explode('|', $method['docblock']['params'][$param]);
+                            $methodTypes = explode('|', $type);
+
+                            sort($docBlockTypes);
+                            sort($methodTypes);
+
+                            if ($docBlockTypes !== $methodTypes) {
+                                if ($type == 'array' && substr($method['docblock']['params'][$param], -2) == '[]') {
+                                    // Do nothing because this is fine.
+                                } else {
+                                    $warnings = true;
+                                    $this->warnings[] = [
+                                        'type' => 'param-mismatch',
+                                        'file' => $file,
+                                        'class' => $name,
+                                        'method' => $name,
+                                        'line' => $method['line'],
+                                        'param' => $param,
+                                        'param-type' => $type,
+                                        'doc-type' => $method['docblock']['params'][$param],
+                                    ];
+                                }
                             }
                         }
                     }

--- a/PhpDocblockChecker/FileProcessor.php
+++ b/PhpDocblockChecker/FileProcessor.php
@@ -140,6 +140,10 @@ class FileProcessor
 
                         $type = substr($type, 0, 1) == '\\' ? substr($type, 1) : $type;
 
+                        if (!is_null($type) && 'null' === $param->default->name->parts[0]) {
+                            $type = $type . '|null';
+                        }
+
                         $thisMethod['params']['$'.$param->name] = $type;
                     }
 


### PR DESCRIPTION
Addition to allow nullable parameters. 
The docblock declaration can be either way around (string|null or null|string).

Passes:

    /**
     * @param array|null $myArray
     */
    function myFunction(array $myArray = null) { ... }

    /**
     * @param string|null $myString
     */
    function myFunction($myString = null) { ... }

Fails:

    /**
     * @param array $myArray
     */
    function myFunction(array $myArray = null) { ... }