### PR TITLE
Fix Several Return Types

### DIFF
--- a/src/Check/ReturnCheck.php
+++ b/src/Check/ReturnCheck.php
@@ -49,17 +49,21 @@ class ReturnCheck extends Check
                 if ($method['docblock']['return'] !== $method['return']) {
                     if ($method['return'] === 'array' && substr($method['docblock']['return'], -2) === '[]') {
                         // Do nothing because this is fine.
-                    } else {
-                        $this->fileStatus->add(
-                            new ReturnMismatchWarning(
-                                $file->getFileName(),
-                                $name,
-                                $method['line'],
-                                $name,
-                                $method['return'],
-                                $method['docblock']['return']
-                            )
-                        );
+		    } else {
+                        $docblockTypes = explode('|', $method['docblock']['return']);
+                        sort($docblockTypes);
+                        if ($method['return'] !== $docblockTypes) {
+                            $this->fileStatus->add(
+                                new ReturnMismatchWarning(
+                                    $file->getFileName(),
+                                    $name,
+                                    $method['line'],
+                                    $name,
+                                    $method['return'],
+                                    $method['docblock']['return']
+                                )
+                            );
+                        }			
                     }
                 }
             }

--- a/src/Check/ReturnCheck.php
+++ b/src/Check/ReturnCheck.php
@@ -49,7 +49,7 @@ class ReturnCheck extends Check
                 if ($method['docblock']['return'] !== $method['return']) {
                     if ($method['return'] === 'array' && substr($method['docblock']['return'], -2) === '[]') {
                         // Do nothing because this is fine.
-		    } else {
+                    } else {
                         $docblockTypes = explode('|', $method['docblock']['return']);
                         sort($docblockTypes);
                         if ($method['return'] !== $docblockTypes) {
@@ -63,7 +63,7 @@ class ReturnCheck extends Check
                                     $method['docblock']['return']
                                 )
                             );
-                        }			
+                        }
                     }
                 }
             }

--- a/src/Status/StatusType/Warning/ReturnMismatchWarning.php
+++ b/src/Status/StatusType/Warning/ReturnMismatchWarning.php
@@ -73,6 +73,8 @@ class ReturnMismatchWarning extends Warning
     {
         return parent::getDecoratedMessage() . '<info>' . $this->method .
             '</info> - @return <fg=blue>' . $this->docType .
-            '</>  does not match method signature (' . $this->returnType . ').';
+            '</>  does not match method signature (' .
+            (is_array($this->returnType) ? implode('|', $this->returnType) : $this->returnType) .
+            ').';
     }
 }


### PR DESCRIPTION
This PR fixes two issues:
1 - When dockblock return has several types
2 - Warning message `getDecoratedMessage` when is array (array to string warning) 

Example:
```php
    /**
     * @return MyClass|null
     */
    protected function doSomething(): ?MyClass
```