### PR TITLE
Opinionated support for ?thing params

### DIFF
--- a/src/FileParser/FileParser.php
+++ b/src/FileParser/FileParser.php
@@ -166,12 +166,13 @@ class FileParser
                             $type = strpos($type, '\\') === 0 ? substr($type, 1) : $type;
                         }
 
-                        if (property_exists($param, 'default') &&
+                        if ((property_exists($param, 'default') &&
                             $param->default instanceof Expr &&
                             property_exists($param->default, 'name') &&
                             property_exists($param->default->name, 'parts') &&
                             $type !== null &&
-                            'null' === $param->default->name->parts[0]
+                            'null' === $param->default->name->parts[0]) ||
+                            $param->type instanceof NullableType
                         ) {
                             $type .= '|null';
                         }


### PR DESCRIPTION
Current behaviour encourages

    /**
     * @param string $thing
     */
    function doStuff(?string $thing) { ... }

I think that it should be:

    /**
     * @param string|null $thing
     */
    function doStuff(?string $thing) { ... }

When the ? is present, the type is nested, with the parent type being NullableType. We deal with this already on line 156 and extract the name of the child, so we can hook into this further to add the '|null' if we have this parent/child combination.

This one might be a bit opinionated, so happy to discuss more...