### PR TITLE
Bug fix for multi-return types

### DIFF
--- a/src/Check/ReturnCheck.php
+++ b/src/Check/ReturnCheck.php
@@ -46,7 +46,7 @@ class ReturnCheck extends Check
                     }
                 }
 
-                if ($method['docblock']['return'] !== $method['return']) {
+                if (!is_array($method['return']) && $method['docblock']['return'] !== $method['return']) {
                     if ($method['return'] === 'array' && substr($method['docblock']['return'], -2) === '[]') {
                         // Do nothing because this is fine.
                     } else {


### PR DESCRIPTION
The block above checks return type and continues IF THERE IS A PROBLEM.
If it's all fine then we end up checking the docblock against the return, which fails, and leads to a messy error message trying to parse an array.