### PR TITLE
Fix nullable return hints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
     }
   },
   "scripts": {
-    "lint": "parallel-lint -e php --exclude vendor .",
+    "lint": "parallel-lint -e php --exclude vendor --exclude tests/FileParser/TestClassPhp7.php .",
     "test": "phpunit",
     "doccheck": "./bin/phpdoccheck",
     "phpcs": "phpcs --extensions=php --cache=.phpcs-cache",

--- a/src/Check/ReturnCheck.php
+++ b/src/Check/ReturnCheck.php
@@ -15,53 +15,40 @@ class ReturnCheck extends Check
     public function check(FileInfo $file)
     {
         foreach ($file->getMethods() as $name => $method) {
-            if (!empty($method['return'])) {
-                if (empty($method['docblock']['return'])) {
-                    $this->fileStatus->add(
-                        new ReturnMissingWarning(
-                            $file->getFileName(),
-                            $name,
-                            $method['line'],
-                            $name
-                        )
-                    );
-                    continue;
-                }
+            if (empty($method['return'])) {
+                // Nothing to check.
+                continue;
+            }
 
-                if (is_array($method['return'])) {
-                    $docblockTypes = explode('|', $method['docblock']['return']);
-                    sort($docblockTypes);
-                    if ($method['return'] !== $docblockTypes) {
-                        $this->fileStatus->add(
-                            new ReturnMismatchWarning(
-                                $file->getFileName(),
-                                $name,
-                                $method['line'],
-                                $name,
-                                implode('|', $method['return']),
-                                $method['docblock']['return']
-                            )
-                        );
-                        continue;
-                    }
-                }
+            if (empty($method['docblock']['return'])) {
+                $this->fileStatus->add(
+                    new ReturnMissingWarning(
+                        $file->getFileName(),
+                        $name,
+                        $method['line'],
+                        $name
+                    )
+                );
+                continue;
+            }
 
-                if ($method['docblock']['return'] !== $method['return']) {
-                    if ($method['return'] === 'array' && substr($method['docblock']['return'], -2) === '[]') {
-                        // Do nothing because this is fine.
-                    } else {
-                        $this->fileStatus->add(
-                            new ReturnMismatchWarning(
-                                $file->getFileName(),
-                                $name,
-                                $method['line'],
-                                $name,
-                                $method['return'],
-                                $method['docblock']['return']
-                            )
-                        );
-                    }
-                }
+            if ($method['return'] === 'array' && substr($method['docblock']['return'], -2) === '[]') {
+                // Do nothing because this is fine.
+                continue;
+            }
+
+            if ($method['return'] !== $method['docblock']['return']) {
+                $this->fileStatus->add(
+                    new ReturnMismatchWarning(
+                        $file->getFileName(),
+                        $name,
+                        $method['line'],
+                        $name,
+                        is_array($method['return']) ? implode('|', $method['return']) : $method['return'],
+                        $method['docblock']['return']
+                    )
+                );
+                continue;
             }
         }
     }

--- a/src/FileParser/FileParser.php
+++ b/src/FileParser/FileParser.php
@@ -286,7 +286,8 @@ class FileParser
 
                     $types[] = strpos($tmpType, '\\') === 0 ? substr($tmpType, 1) : $tmpType;
                 }
-                $rtn['return'] = implode('|', $types);
+                sort($types);
+                $rtn['return'] = count($types) === 1 ? $types[0] : $types;
             }
         }
 

--- a/tests/FileParser/FileParserTestPhp7.php
+++ b/tests/FileParser/FileParserTestPhp7.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace PhpDocBlockChecker\FileParser;
+
+use PhpDocBlockChecker\DocblockParser\DocblockParser;
+use PhpParser\ParserFactory;
+
+/**
+ * @requires PHP 7.0
+ */
+class FileParserTest extends \PHPUnit_Framework_TestCase
+{
+    protected $filePath = __DIR__ . '/TestClassPhp7.php';
+    protected $fileInfo;
+
+    protected function setUp()
+    {
+        $fileParser = new FileParser(
+            (new ParserFactory())->create(ParserFactory::PREFER_PHP7),
+            new DocblockParser()
+        );
+
+        $this->fileInfo = $fileParser->parseFile($this->filePath);
+    }
+
+    public function testFileLoaded()
+    {
+        $this->assertEquals($this->filePath, $this->fileInfo->getFileName());
+    }
+
+    /**
+     * @requires PHP 7.0
+     */
+    public function testWithReturnHint()
+    {
+        $method = $this->fileInfo->getMethods()['PhpDocBlockChecker\FileParser\TestClass::withReturnHint'];
+        $this->assertTrue($method['has_return']);
+        $this->assertEquals('string', $method['return']);
+        $this->assertEquals('string', $method['docblock']['return']);
+    }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function testWithNullableReturnHint()
+    {
+        $method = $this->fileInfo->getMethods()['PhpDocBlockChecker\FileParser\TestClass::withNullableReturnHint'];
+        $this->assertTrue($method['has_return']);
+        $this->assertEquals(['null', 'string'], $method['return']);
+        $this->assertEquals(['null', 'string'], $method['docblock']['return']);
+    }
+
+    /**
+     * @requires PHP 7.1
+     */
+    public function testWithMixedOrderNullableReturnHint()
+    {
+        $method = $this->fileInfo->getMethods()['PhpDocBlockChecker\FileParser\TestClass::withMixedOrderNullableReturnHint'];
+        $this->assertTrue($method['has_return']);
+        $this->assertEquals(['null', 'string'], $method['return']);
+        $this->assertEquals(['null', 'string'], $method['docblock']['return']);
+    }
+}

--- a/tests/FileParser/TestClass.php
+++ b/tests/FileParser/TestClass.php
@@ -4,16 +4,16 @@ namespace PhpDocBlockChecker\FileParser;
 
 class TestClass
 {
-    public function foo()
+    public function emptyMethod()
     {
     }
 
-    public function bar($foo, $bar, $baz)
+    public function withParams($foo, $bar, $baz)
     {
     }
 
-    public function baz()
+    public function withReturn()
     {
-        return true;
+        return 'test';
     }
 }

--- a/tests/FileParser/TestClassPhp7.php
+++ b/tests/FileParser/TestClassPhp7.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PhpDocBlockChecker\FileParser;
+
+class TestClass
+{
+    /**
+     * @return string
+     */
+    public function withReturnHint(): string
+    {
+        return 'test';
+    }
+
+    /**
+     * @return string|null
+     */
+    public function withNullableReturnHint(): ?string
+    {
+        return 'test';
+    }
+
+    /**
+     * @return null|string
+     */
+    public function withMixedOrderNullableReturnHint(): ?string
+    {
+        return 'test';
+    }
+}


### PR DESCRIPTION
Fixes an error when checking PHP 7.1 nullable return types, e.g.

```
Notice: Array to string conversion in /testFile.php on line 76
WARNING  TestClass::testMethod - @return string|null  does not match method signature (Array).
```

Additional PHP 7 tests have been split out to avoid breaking test runs on PHP 5.